### PR TITLE
chore(typos): fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The precedence for the overrides is:
 
 #### Special overrides
 
-There are a few sources which are used in multiple installations. For those sources, there is an override that globaly overrides all installations from this sources. Here is the list of those sources and their keys.
+There are a few sources which are used in multiple installations. For those sources, there is an override that globally overrides all installations from this sources. Here is the list of those sources and their keys.
 
 ```
 DEV_FEATURE_OVERRIDE_GITHUB_DOWNLOAD_URL=...

--- a/build/build.go
+++ b/build/build.go
@@ -411,7 +411,7 @@ func testFeature(featureName string) error {
 			if checkError != nil {
 				return fmt.Errorf("check failed: %w", checkError)
 			}
-			fmt.Println("Check was successfull")
+			fmt.Println("Check was successful")
 		}
 	}
 

--- a/features/src/cypress-deps/NOTES.md
+++ b/features/src/cypress-deps/NOTES.md
@@ -17,7 +17,7 @@ Also don't forget to add `.cypress_cache` to your `.gitignore` file.
 
 ### x11 Socket
 
-The Cypress UI in the dev-container is displayed via x11. If the corresponding socket is not correcly forwarded into the container, this can lead to heavy performance loss due to higher CPU usage.
+The Cypress UI in the dev-container is displayed via x11. If the corresponding socket is not correctly forwarded into the container, this can lead to heavy performance loss due to higher CPU usage.
 
 To correctly forward the x11 socket into the container, make sure to add the following variables to the `runArgs`:
 ```

--- a/features/src/cypress-deps/README.md
+++ b/features/src/cypress-deps/README.md
@@ -30,7 +30,7 @@ Also don't forget to add `.cypress_cache` to your `.gitignore` file.
 
 ### x11 Socket
 
-The Cypress UI in the dev-container is displayed via x11. If the corresponding socket is not correcly forwarded into the container, this can lead to heavy performance loss due to higher CPU usage.
+The Cypress UI in the dev-container is displayed via x11. If the corresponding socket is not correctly forwarded into the container, this can lead to heavy performance loss due to higher CPU usage.
 
 To correctly forward the x11 socket into the container, make sure to add the following variables to the `runArgs`:
 ```

--- a/features/src/node/NOTES.md
+++ b/features/src/node/NOTES.md
@@ -16,7 +16,7 @@ Needs access to the following URL for downloading and resolving:
 
 :warning: Internet access is necessary for corepack to install your preferred package manager.
 
-If you prefere to use internal sources, additional configuration is required. Add this to your `devcontainer.json`.
+If you prefer to use internal sources, additional configuration is required. Add this to your `devcontainer.json`.
 
 ```json
   {
@@ -39,4 +39,4 @@ For **pnpm** to work with Artifactory, you have to additionally add this to the 
   }
 ```
 
-The reason for this are missing singatures in the Artifactory NPM API. See [nodejs/corepack#725](https://github.com/nodejs/corepack/issues/725)
+The reason for this are missing signatures in the Artifactory NPM API. See [nodejs/corepack#725](https://github.com/nodejs/corepack/issues/725)

--- a/features/src/node/README.md
+++ b/features/src/node/README.md
@@ -50,7 +50,7 @@ Needs access to the following URL for downloading and resolving:
 
 :warning: Internet access is necessary for corepack to install your preferred package manager.
 
-If you prefere to use internal sources, additional configuration is required. Add this to your `devcontainer.json`.
+If you prefer to use internal sources, additional configuration is required. Add this to your `devcontainer.json`.
 
 ```json
   {
@@ -73,4 +73,4 @@ For **pnpm** to work with Artifactory, you have to additionally add this to the 
   }
 ```
 
-The reason for this are missing singatures in the Artifactory NPM API. See [nodejs/corepack#725](https://github.com/nodejs/corepack/issues/725)
+The reason for this are missing signatures in the Artifactory NPM API. See [nodejs/corepack#725](https://github.com/nodejs/corepack/issues/725)

--- a/installer/feature.go
+++ b/installer/feature.go
@@ -122,7 +122,7 @@ func (f *Feature) Process() error {
 	return nil
 }
 
-// This is the inferface that needs to be implemented by a component.
+// This is the interface that needs to be implemented by a component.
 type IComponent interface {
 	// Returns the name of the component.
 	GetName() string


### PR DESCRIPTION
Just some typos found by [`crate-ci/typos`](https://github.com/crate-ci/typos)